### PR TITLE
Fix React imports and compile JSX in browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <title>SPN Logistics</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://unpkg.com/gsap@3/dist/gsap.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="bg-gray-100 text-gray-800">
   <div id="root"></div>
@@ -14,6 +15,6 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/emailjs-com@3/dist/email.min.js"></script>
-  <script type="module" src="js/app.js"></script>
+  <script type="text/babel" data-presets="react" src="js/app.js"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,6 +1,4 @@
-import React from 'https://esm.sh/react@18.2.0';
-import ReactDOM from 'https://esm.sh/react-dom@18.2.0/client';
-import { BrowserRouter as Router, Routes, Route, Link } from 'https://esm.sh/react-router-dom@6.18.0';
+const { BrowserRouter: Router, Routes, Route, Link } = ReactRouterDOM;
 
 // initialize EmailJS
 window.emailjs && emailjs.init('YOUR_PUBLIC_KEY');


### PR DESCRIPTION
## Summary
- load Babel standalone to compile JSX on the fly
- drop ESM imports in `app.js` and use globals from UMD scripts
- run `app.js` using the Babel `text/babel` script type

## Testing
- `bash build.sh` *(fails: 403 Forbidden while downloading esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_6841d59288cc8320a7224b9cb509a3a1