### PR TITLE
Fix JS bundle reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,6 @@
 <body class="bg-gray-100 text-gray-800">
   <div id="root"></div>
   <script src="https://cdn.jsdelivr.net/npm/emailjs-com@3/dist/email.min.js"></script>
-  <script src="js/app.compiled.js"></script>
+  <script src="js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the bundled JS from `js/app.js` instead of the precompiled file

## Testing
- `bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68420ce61c408320bdca273daa4ef6aa