### PR TITLE
Fix ReactRouterDOM initialization

### DIFF
--- a/js/app.compiled.js
+++ b/js/app.compiled.js
@@ -6,7 +6,7 @@
     Route,
     Link,
     NavLink: RouterNavLink
-  } = ReactRouterDOM;
+  } = window.ReactRouterDOM || {};
   window.emailjs && emailjs.init("YOUR_PUBLIC_KEY");
   var { motion, useInView } = Motion;
   var Hero = () => /* @__PURE__ */ React.createElement("section", { className: "relative h-screen overflow-hidden" }, /* @__PURE__ */ React.createElement(

--- a/js/app.js
+++ b/js/app.js
@@ -4,7 +4,7 @@ const {
   Route,
   Link,
   NavLink: RouterNavLink,
-} = ReactRouterDOM;
+} = window.ReactRouterDOM || {};
 
 // initialize EmailJS
 window.emailjs && emailjs.init('YOUR_PUBLIC_KEY');


### PR DESCRIPTION
## Summary
- avoid ReferenceError when ReactRouterDOM is unavailable by reading from `window`

## Testing
- `bash build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68420f01e5e48320b19c16f51873f35b