### PR TITLE
Fix mobile nav and remove brand text

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -497,8 +497,7 @@ const Layout = ({ children }) => {
   return (
     <div>
       <nav className="fixed top-0 left-0 w-full z-50 text-white bg-black/50 backdrop-blur shadow-md">
-        <div className="max-w-6xl mx-auto flex items-center justify-between p-4">
-          <h1 className="text-xl font-bold">SPN Logistics</h1>
+        <div className="max-w-6xl mx-auto flex items-center justify-end p-4">
           <button className="md:hidden focus:outline-none" onClick={toggle} aria-label="Menu">
             {open ? <i className="fas fa-times text-2xl"></i> : <i className="fas fa-bars text-2xl"></i>}
           </button>
@@ -509,7 +508,7 @@ const Layout = ({ children }) => {
             </button>
           </div>
         </div>
-        <div className={`md:hidden overflow-hidden transition-all duration-300 ${open ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}>
+        <div className={`md:hidden ${open ? 'block' : 'hidden'} bg-black/70`}>
           <div className="px-4 pb-4 space-y-1">
             <Links />
             <button onClick={toggleDark} aria-label="Toggle dark mode" className="block mt-2">


### PR DESCRIPTION
## Summary
- remove company name from navigation bar
- show dropdown links properly on small screens

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ca970e9c8320be2a5bc8f7b7d085