### PR TITLE
Update services and layout

### DIFF
--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -59,7 +59,7 @@ const Footer: React.FC = () => {
               <span className="font-bold text-xl">
                 <CountUp end={1500} suffix="+" />
               </span>
-              <span>Dedicated Drivers</span>
+              <span>Satisfied Clients</span>
             </p>
             <p className="flex items-center gap-2">
               <span className="font-bold text-xl">

--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -36,7 +36,7 @@ const Navbar: React.FC = () => {
             </NavLink>
           </li>
           <li>
-            <NavLink to="/services/ltl" className={({ isActive }) => (isActive ? 'text-primary' : '')}>
+            <NavLink to="/services" className={({ isActive }) => (isActive ? 'text-primary' : '')}>
               Services
             </NavLink>
           </li>
@@ -67,7 +67,7 @@ const Navbar: React.FC = () => {
               </NavLink>
             </li>
             <li>
-              <NavLink to="/services/ltl" onClick={() => setIsOpen(false)}>
+              <NavLink to="/services" onClick={() => setIsOpen(false)}>
                 Services
               </NavLink>
             </li>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -34,9 +34,9 @@ const About: React.FC = () => {
       <Section title="We Provide All Kinds of Services">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {[
-            { src: RefrigeratedImg, label: "Refrigerated" },
             { src: DryVanImg, label: "Dry Van" },
             { src: SemiTruckImg, label: "Flatbed" },
+            { src: RefrigeratedImg, label: "Refrigerated" },
           ].map(({ src, label }, idx) => (
             <motion.div
               key={idx}
@@ -59,7 +59,7 @@ const About: React.FC = () => {
       </Section>
 
       <Section title="Executive Team">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 justify-center">
           {[
             {
               name: "Parminder Singh",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,6 +5,8 @@ import CountUp from 'react-countup';
 import Section from '../ui/Section';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
+import { Truck, Route, Package, CheckCircle } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 import partnerImg1 from '../assets/ChatGPT Image Jun 7, 2025, 02_58_55 PM.png';
 import partnerImg2 from '../assets/ChatGPT Image Jun 7, 2025, 03_00_03 PM.png';
 import partnerImg3 from '../assets/ChatGPT Image Jun 7, 2025, 03_00_52 PM.png';
@@ -60,6 +62,7 @@ const Home: React.FC = () => {
   ];
 
   const partnerImages = [partnerImg1, partnerImg2, partnerImg3, partnerImg4];
+  const navigate = useNavigate();
 
   return (
     <>
@@ -109,27 +112,31 @@ const Home: React.FC = () => {
       {/* Stats Section */}
       <Section>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
-          <div>
+          <div className="flex flex-col items-center gap-2">
+            <Truck className="text-primary" />
             <p className="text-3xl font-bold text-primary">
-              <CountUp end={20} />+
+              <CountUp end={20} duration={4} />+
             </p>
             <p>Years in Service</p>
           </div>
-          <div>
+          <div className="flex flex-col items-center gap-2">
+            <Route className="text-primary" />
             <p className="text-3xl font-bold text-primary">
-              <CountUp end={5000000} suffix="+" />
+              <CountUp end={5000000} suffix="+" duration={4} />
             </p>
             <p>Miles Driven</p>
           </div>
-          <div>
+          <div className="flex flex-col items-center gap-2">
+            <Package className="text-primary" />
             <p className="text-3xl font-bold text-primary">
-              <CountUp end={12000} suffix="+" />
+              <CountUp end={12000} suffix="+" duration={4} />
             </p>
             <p>Loads Delivered</p>
           </div>
-          <div>
+          <div className="flex flex-col items-center gap-2">
+            <CheckCircle className="text-primary" />
             <p className="text-3xl font-bold text-primary">
-              <CountUp end={99} suffix="%" />
+              <CountUp end={99} suffix="%" duration={4} />
             </p>
             <p>On-Time Rate</p>
           </div>
@@ -145,7 +152,12 @@ const Home: React.FC = () => {
             { title: 'Refrigerated Transport', slug: 'refrigerated' },
             { title: 'Cross-Border', slug: 'cross-border' },
           ].map((service) => (
-            <Card key={service.slug} title={service.title} subtitle="Learn More" />
+            <Card
+              key={service.slug}
+              title={service.title}
+              subtitle="Learn More"
+              onClick={() => navigate(`/services/${service.slug}`)}
+            />
           ))}
         </div>
       </Section>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+import { Helmet } from 'react-helmet-async';
+import { getAllServices } from '../services/api';
+import Section from '../ui/Section';
+import Card from '../ui/Card';
+import { Link } from 'react-router-dom';
+
+interface ServiceInfo {
+  slug: string;
+  title: string;
+  description: string;
+}
+
+const Services: React.FC = () => {
+  const [services, setServices] = useState<ServiceInfo[]>([]);
+
+  useEffect(() => {
+    setServices(getAllServices());
+  }, []);
+
+  return (
+    <>
+      <Helmet>
+        <title>SPN Logistics | Services</title>
+      </Helmet>
+      <Section title="Our Services">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {services.map((service) => (
+            <Card key={service.slug} title={service.title} className="space-y-2">
+              <p>{service.description}</p>
+              <Link className="text-primary underline" to={`/services/${service.slug}`}>
+                Learn More
+              </Link>
+            </Card>
+          ))}
+        </div>
+      </Section>
+    </>
+  );
+};
+
+export default Services;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -8,6 +8,7 @@ import ScrollTop from '../layout/ScrollTop';
 const Home = lazy(() => import('../pages/Home'));
 const About = lazy(() => import('../pages/About'));
 const Careers = lazy(() => import('../pages/Careers'));
+const Services = lazy(() => import('../pages/Services'));
 const ServiceDetails = lazy(() => import('../pages/ServiceDetails'));
 const Contact = lazy(() => import('../pages/Contact'));
 const NotFound = lazy(() => import('../pages/NotFound'));
@@ -22,6 +23,7 @@ const AppRoutes: React.FC = () => {
           <Route path="/" element={<Home />} />
           <Route path="/about" element={<About />} />
           <Route path="/careers" element={<Careers />} />
+          <Route path="/services" element={<Services />} />
           <Route path="/services/:slug" element={<ServiceDetails />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="*" element={<NotFound />} />

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -6,12 +6,40 @@ import { QueryClient } from '@tanstack/react-query';
 export const apiClient = new QueryClient();
 
 // Example stub function
-export async function fetchServiceDetails(slug: string) {
+interface ServiceInfo {
+  slug: string;
+  title: string;
+  description: string;
+}
+
+const servicesData: Record<string, Omit<ServiceInfo, 'slug'>> = {
+  ltl: {
+    title: 'LTL Shipping',
+    description:
+      'Less-than-truckload service ideal for small freight that doesn\'t require a full trailer.'
+  },
+  ftl: {
+    title: 'FTL Shipping',
+    description:
+      'Full truckload solutions for high-volume shipments that need dedicated space.'
+  },
+  refrigerated: {
+    title: 'Refrigerated Transport',
+    description:
+      'Temperature-controlled trailers keeping perishables fresh across long distances.'
+  },
+  'cross-border': {
+    title: 'Cross-Border',
+    description:
+      'Hassle-free shipping across Canada and the United States with our customs expertise.'
+  }
+};
+
+export function getAllServices(): ServiceInfo[] {
+  return Object.entries(servicesData).map(([slug, data]) => ({ slug, ...data }));
+}
+
+export async function fetchServiceDetails(slug: string): Promise<ServiceInfo> {
   // In real scenario, you'd fetch from an API
-  // For now, let's return some mock data:
-  return {
-    slug,
-    title: slug.toUpperCase() + ' Transportation',
-    description: `Details about our ${slug.toUpperCase()} service.`
-  };
+  return { slug, ...(servicesData[slug] ?? { title: 'Service', description: '' }) };
 }


### PR DESCRIPTION
## Summary
- add icons and slower counters on home page stats
- link home service cards to individual pages
- add new Services page and route
- reorder service images and center exec team
- update footer metric label

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6844f656d1e88320af5965fc7324d162