### PR TITLE
Update service pages and remove cross-border option

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -42,7 +42,7 @@ const Home: React.FC = () => {
     },
     {
       quote:
-        'Their cross-border expertise has been game-changing for our supply chain.',
+        'Their long-haul expertise has been game-changing for our supply chain.',
       name: 'Jane Smith',
       role: 'Operations Director, Global X',
       avatar: reviewWomen,
@@ -150,7 +150,6 @@ const Home: React.FC = () => {
             { title: 'LTL Shipping', slug: 'ltl' },
             { title: 'FTL Shipping', slug: 'ftl' },
             { title: 'Refrigerated Transport', slug: 'refrigerated' },
-            { title: 'Cross-Border', slug: 'cross-border' },
           ].map((service) => (
             <Card
               key={service.slug}

--- a/src/pages/ServiceDetails.tsx
+++ b/src/pages/ServiceDetails.tsx
@@ -34,8 +34,15 @@ const ServiceDetails: React.FC = () => {
         <title>SPN Logistics | {service.title}</title>
         <meta name="description" content={`Details about ${service.title}.`} />
       </Helmet>
-      <div className="max-w-5xl mx-auto p-4 mt-20">
-        <h1 className="text-3xl font-bold text-primary mb-4">{service.title}</h1>
+      <div className="max-w-5xl mx-auto p-4 mt-20 space-y-4">
+        {service.image && (
+          <img
+            src={service.image}
+            alt={service.title}
+            className="w-full h-64 object-cover rounded"
+          />
+        )}
+        <h1 className="text-3xl font-bold text-primary">{service.title}</h1>
         <p>{service.description}</p>
       </div>
     </>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -9,6 +9,7 @@ interface ServiceInfo {
   slug: string;
   title: string;
   description: string;
+  image: string;
 }
 
 const Services: React.FC = () => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,4 +1,7 @@
 import { QueryClient } from '@tanstack/react-query';
+import DryVanImg from '../assets/dryvan.png';
+import SemiTruckImg from '../assets/semitruck.png';
+import ReeferImg from '../assets/Refrigerated.png';
 
 // This file can be used for real or mock API calls
 // Currently a placeholder for future expansions
@@ -10,28 +13,27 @@ interface ServiceInfo {
   slug: string;
   title: string;
   description: string;
+  image: string;
 }
 
 const servicesData: Record<string, Omit<ServiceInfo, 'slug'>> = {
   ltl: {
     title: 'LTL Shipping',
     description:
-      'Less-than-truckload service ideal for small freight that doesn\'t require a full trailer.'
+      'Our less-than-truckload service consolidates your freight with other shipments for a cost-effective solution that still meets your deadlines.',
+    image: DryVanImg
   },
   ftl: {
     title: 'FTL Shipping',
     description:
-      'Full truckload solutions for high-volume shipments that need dedicated space.'
+      'Full truckload options give your cargo exclusive use of a trailer, ideal for high-volume or time-sensitive freight that requires a direct route.',
+    image: SemiTruckImg
   },
   refrigerated: {
     title: 'Refrigerated Transport',
     description:
-      'Temperature-controlled trailers keeping perishables fresh across long distances.'
-  },
-  'cross-border': {
-    title: 'Cross-Border',
-    description:
-      'Hassle-free shipping across Canada and the United States with our customs expertise.'
+      'Our modern reefer fleet keeps temperature-sensitive goods fresh and compliant from pickup through delivery, no matter the distance.',
+    image: ReeferImg
   }
 };
 
@@ -41,5 +43,12 @@ export function getAllServices(): ServiceInfo[] {
 
 export async function fetchServiceDetails(slug: string): Promise<ServiceInfo> {
   // In real scenario, you'd fetch from an API
-  return { slug, ...(servicesData[slug] ?? { title: 'Service', description: '' }) };
+  return {
+    slug,
+    ...(servicesData[slug] ?? {
+      title: 'Service',
+      description: '',
+      image: ''
+    })
+  };
 }


### PR DESCRIPTION
## Summary
- add images and longer descriptions for services
- remove cross-border service
- show service images on service details page
- update testimonial text

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined)*
- `pnpm exec tsc -p tsconfig.json` *(fails: TypeScript errors in zod package)*

------
https://chatgpt.com/codex/tasks/task_e_6844fd789080832084251f9b93577684