### PR TITLE
Center services grid and add icons

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -5,7 +5,7 @@ import CountUp from 'react-countup';
 import Section from '../ui/Section';
 import Card from '../ui/Card';
 import Button from '../ui/Button';
-import { Truck, Route, Package, CheckCircle } from 'lucide-react';
+import { Truck, Route, Package, CheckCircle, Snowflake } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import partnerImg1 from '../assets/ChatGPT Image Jun 7, 2025, 02_58_55 PM.png';
 import partnerImg2 from '../assets/ChatGPT Image Jun 7, 2025, 03_00_03 PM.png';
@@ -145,17 +145,31 @@ const Home: React.FC = () => {
 
       {/* Services Grid */}
       <Section title="Our Services">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto justify-items-center">
           {[
-            { title: 'LTL Shipping', slug: 'ltl' },
-            { title: 'FTL Shipping', slug: 'ftl' },
-            { title: 'Refrigerated Transport', slug: 'refrigerated' },
+            {
+              title: 'LTL Shipping',
+              slug: 'ltl',
+              icon: <Package className="w-10 h-10 text-primary" />,
+            },
+            {
+              title: 'FTL Shipping',
+              slug: 'ftl',
+              icon: <Truck className="w-10 h-10 text-primary" />,
+            },
+            {
+              title: 'Refrigerated Transport',
+              slug: 'refrigerated',
+              icon: <Snowflake className="w-10 h-10 text-primary" />,
+            },
           ].map((service) => (
             <Card
               key={service.slug}
               title={service.title}
               subtitle="Learn More"
+              icon={service.icon}
               onClick={() => navigate(`/services/${service.slug}`)}
+              className="text-center"
             />
           ))}
         </div>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -4,6 +4,7 @@ import { getAllServices } from '../services/api';
 import Section from '../ui/Section';
 import Card from '../ui/Card';
 import { Link } from 'react-router-dom';
+import { Package, Truck, Snowflake } from 'lucide-react';
 
 interface ServiceInfo {
   slug: string;
@@ -15,6 +16,12 @@ interface ServiceInfo {
 const Services: React.FC = () => {
   const [services, setServices] = useState<ServiceInfo[]>([]);
 
+  const serviceIcons: Record<string, React.ReactNode> = {
+    ltl: <Package className="w-10 h-10 text-primary" />,
+    ftl: <Truck className="w-10 h-10 text-primary" />,
+    refrigerated: <Snowflake className="w-10 h-10 text-primary" />,
+  };
+
   useEffect(() => {
     setServices(getAllServices());
   }, []);
@@ -25,13 +32,16 @@ const Services: React.FC = () => {
         <title>SPN Logistics | Services</title>
       </Helmet>
       <Section title="Our Services">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto justify-items-center">
           {services.map((service) => (
-            <Card key={service.slug} title={service.title} className="space-y-2">
+            <Card
+              key={service.slug}
+              title={service.title}
+              icon={serviceIcons[service.slug]}
+              className="space-y-2 text-center"
+            >
               <p>{service.description}</p>
-              <Link className="text-primary underline" to={`/services/${service.slug}`}>
-                Learn More
-              </Link>
+              <Link className="text-primary underline" to={`/services/${service.slug}`}>Learn More</Link>
             </Card>
           ))}
         </div>

--- a/src/ui/Card.tsx
+++ b/src/ui/Card.tsx
@@ -7,9 +7,17 @@ interface CardProps {
   children?: React.ReactNode;
   onClick?: () => void;
   className?: string;
+  icon?: React.ReactNode;
 }
 
-const Card: React.FC<CardProps> = ({ title, subtitle, children, onClick, className = '' }) => {
+const Card: React.FC<CardProps> = ({
+  title,
+  subtitle,
+  children,
+  onClick,
+  className = '',
+  icon,
+}) => {
   return (
     <motion.div
       whileHover={{ scale: 1.02 }}
@@ -17,6 +25,7 @@ const Card: React.FC<CardProps> = ({ title, subtitle, children, onClick, classNa
       className={`bg-white dark:bg-darkBg2 p-5 rounded-md shadow-md cursor-pointer ${className}`}
       onClick={onClick}
     >
+      {icon && <div className="mb-4 flex justify-center">{icon}</div>}
       <h3 className="text-lg font-semibold mb-2 text-primary">{title}</h3>
       {subtitle && <p className="text-sm text-gray-500 dark:text-gray-300">{subtitle}</p>}
       <div className="mt-2">{children}</div>


### PR DESCRIPTION
## Summary
- show icons at the top of `Card`
- center the services grid and use matching icons on the Services page
- update the Home page services grid to use icons and center layout

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_684501441bfc8320976e00dc70ce67cb