### PR TITLE
Update service section texts and center layouts

### DIFF
--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -69,12 +69,24 @@ const About: React.FC = () => {
         </div>
       </Section>
 
-      <Section title="We Provide All Kinds of Services">
+      <Section title="We Provide All Kinds of Services to Fleet">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
           {[
-            { src: DryVanImg, label: "Dry Van" },
-            { src: SemiTruckImg, label: "Flatbed" },
-            { src: RefrigeratedImg, label: "Refrigerated" },
+            {
+              src: DryVanImg,
+              label:
+                "Our dry vans keep freight secure and protected from the elements.",
+            },
+            {
+              src: SemiTruckImg,
+              label:
+                "We operate all kinds of semi trucks to handle diverse hauling needs.",
+            },
+            {
+              src: RefrigeratedImg,
+              label:
+                "Reefer trailers maintain temperature for your perishable goods.",
+            },
           ].map(({ src, label }, idx) => (
             <motion.div
               key={idx}
@@ -97,7 +109,7 @@ const About: React.FC = () => {
       </Section>
 
       <Section title="Executive Team">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 justify-center">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 justify-center place-items-center">
           {[
             {
               name: "Parminder Singh",

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -200,7 +200,7 @@ const Home: React.FC = () => {
 
       {/* Testimonials */}
       <Section title="What Our Clients Say">
-        <Slider {...testimonialSettings}>
+        <Slider {...testimonialSettings} className="max-w-xl mx-auto">
           {testimonials.map(({ quote, name, role, avatar }) => (
             <div key={name} className="p-4">
               <blockquote className="bg-white dark:bg-darkBg2 p-6 rounded shadow">


### PR DESCRIPTION
## Summary
- clarify service descriptions on About page
- center the co-founder grid
- center testimonials slider on Home page

## Testing
- `pnpm test` *(fails: Cannot destructure property 'future' of 'React__namespace.useContext(...)' as it is null)*

------
https://chatgpt.com/codex/tasks/task_e_68450f74f81c8320b56038603d717393