### PR TITLE
Remove unused service detail links

### DIFF
--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -21,7 +21,7 @@ const Footer: React.FC = () => {
               <NavLink to="/careers">Careers</NavLink>
             </li>
             <li>
-              <NavLink to="/services/ltl">Services</NavLink>
+              <NavLink to="/services">Services</NavLink>
             </li>
             <li>
               <NavLink to="/contact">Contact</NavLink>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -167,7 +167,7 @@ const Home: React.FC = () => {
               title={service.title}
               subtitle="Learn More"
               icon={service.icon}
-              onClick={() => navigate(`/services/${service.slug}`)}
+              onClick={() => navigate('/services')}
               className="text-center"
             />
           ))}

--- a/src/pages/ServiceDetails.tsx
+++ b/src/pages/ServiceDetails.tsx
@@ -17,7 +17,7 @@ const ServiceDetails: React.FC = () => {
   }, [slug]);
 
   if (!slug) {
-    return <Navigate to="/services/ltl" replace />;
+    return <Navigate to="/services" replace />;
   }
 
   if (error) {

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet-async';
 import { getAllServices } from '../services/api';
 import Section from '../ui/Section';
 import Card from '../ui/Card';
-import { Link } from 'react-router-dom';
 import { Package, Truck, Snowflake } from 'lucide-react';
 
 interface ServiceInfo {
@@ -41,7 +40,6 @@ const Services: React.FC = () => {
               className="space-y-2 text-center"
             >
               <p>{service.description}</p>
-              <Link className="text-primary underline" to={`/services/${service.slug}`}>Learn More</Link>
             </Card>
           ))}
         </div>

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -9,7 +9,6 @@ const Home = lazy(() => import('../pages/Home'));
 const About = lazy(() => import('../pages/About'));
 const Careers = lazy(() => import('../pages/Careers'));
 const Services = lazy(() => import('../pages/Services'));
-const ServiceDetails = lazy(() => import('../pages/ServiceDetails'));
 const Contact = lazy(() => import('../pages/Contact'));
 const NotFound = lazy(() => import('../pages/NotFound'));
 
@@ -24,7 +23,6 @@ const AppRoutes: React.FC = () => {
           <Route path="/about" element={<About />} />
           <Route path="/careers" element={<Careers />} />
           <Route path="/services" element={<Services />} />
-          <Route path="/services/:slug" element={<ServiceDetails />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="*" element={<NotFound />} />
         </Routes>


### PR DESCRIPTION
## Summary
- drop the `/services/:slug` route
- update home page service cards to link to `/services`
- remove "Learn More" links from the Services page
- fix footer navigation to point at `/services`
- redirect ServiceDetails to `/services` if slug missing

## Testing
- `pnpm test` *(fails: Cannot destructure property 'future' ...)*

------
https://chatgpt.com/codex/tasks/task_e_684515ce46908320852ffce1a853a152