### PR TITLE
Update fonts and remove fleet stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SPN Logistics</title>
   </head>
-  <body class="bg-white dark:bg-darkBg text-gray-800 dark:text-gray-100">
+  <body class="bg-white dark:bg-darkBg text-gray-800 dark:text-gray-100 font-body">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "react-router-dom": "^6.11.1",
     "react-slick": "^0.29.0",
     "slick-carousel": "^1.8.1",
-    "zod": "^3.20.6"
+    "zod": "^3.20.6",
+    "@fontsource/roboto": "^5.2.6",
+    "@fontsource/playfair-display": "^5.2.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/layout/Footer.tsx
+++ b/src/layout/Footer.tsx
@@ -51,12 +51,6 @@ const Footer: React.FC = () => {
           <div className="space-y-2">
             <p className="flex items-center gap-2">
               <span className="font-bold text-xl">
-                <CountUp end={650} suffix="+" />
-              </span>
-              <span>Fleet Vehicles</span>
-            </p>
-            <p className="flex items-center gap-2">
-              <span className="font-bold text-xl">
                 <CountUp end={1500} suffix="+" />
               </span>
               <span>Satisfied Clients</span>

--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -8,7 +8,7 @@ const Navbar: React.FC = () => {
   return (
     <header className="fixed top-0 left-0 w-full z-50 bg-black/50 backdrop-blur-sm text-white">
       <nav className="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
-        <Link to="/" className="font-bold text-xl tracking-wide">
+        <Link to="/" className="font-bold text-xl tracking-wide font-heading">
           SPN Logistics
         </Link>
         <button

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,8 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './styles/tailwind.css';
+import '@fontsource/roboto';
+import '@fontsource/playfair-display';
 import 'aos/dist/aos.css';
 
 // Initialize React Query client

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -89,7 +89,7 @@ const Home: React.FC = () => {
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.8 }}
-            className="text-4xl md:text-6xl font-bold mb-4"
+            className="text-4xl md:text-6xl font-bold mb-4 font-heading"
           >
             Drive Forward with SPN Logistics
           </motion.h1>

--- a/src/ui/Section.tsx
+++ b/src/ui/Section.tsx
@@ -16,7 +16,7 @@ const Section: React.FC<SectionProps> = ({ id, title, children }) => {
           whileInView={{ opacity: 1, x: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.5 }}
-          className="text-2xl md:text-3xl font-bold text-center mb-8 text-primary"
+          className="text-2xl md:text-3xl font-bold text-center mb-8 text-primary font-heading"
         >
           {title}
         </motion.h2>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,10 @@ module.exports = {
   darkMode: 'class',
   theme: {
     extend: {
+      fontFamily: {
+        heading: ['"Playfair Display"', 'serif'],
+        body: ['Roboto', 'sans-serif'],
+      },
       colors: {
         primary: '#FF5722',
         darkBg: '#0d1321',


### PR DESCRIPTION
## Summary
- remove fleet vehicle stats
- add Playfair Display and Roboto fonts
- apply fonts to headings and body

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a1d5fedc8320a4de12f6e183ebdc