### PR TITLE
Add page padding and scroll restoration

### DIFF
--- a/src/layout/ScrollToTopOnRouteChange.tsx
+++ b/src/layout/ScrollToTopOnRouteChange.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTopOnRouteChange: React.FC = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTopOnRouteChange;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router-dom';
 import Navbar from '../layout/Navbar';
 import Footer from '../layout/Footer';
 import ScrollTop from '../layout/ScrollTop';
+import ScrollToTopOnRouteChange from '../layout/ScrollToTopOnRouteChange';
 
 // Lazy-loaded pages
 const Home = lazy(() => import('../pages/Home'));
@@ -16,17 +17,26 @@ const AppRoutes: React.FC = () => {
   return (
     <>
       <Navbar />
+      <ScrollToTopOnRouteChange />
       <ScrollTop />
-      <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading...</div>}>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/careers" element={<Careers />} />
-          <Route path="/services" element={<Services />} />
-          <Route path="/contact" element={<Contact />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </Suspense>
+      <main className="pt-20">
+        <Suspense
+          fallback={
+            <div className="min-h-screen flex items-center justify-center">
+              Loading...
+            </div>
+          }
+        >
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/careers" element={<Careers />} />
+            <Route path="/services" element={<Services />} />
+            <Route path="/contact" element={<Contact />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
+      </main>
       <Footer />
     </>
   );


### PR DESCRIPTION
## Summary
- ensure routes scroll to top on navigation
- add padding-top for content so it doesn't sit under the fixed navbar

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6845ad62ea0c83209e94e4f135fc84ed