### PR TITLE
Improve truck nav readability

### DIFF
--- a/src/layout/TruckNavLink.tsx
+++ b/src/layout/TruckNavLink.tsx
@@ -22,13 +22,11 @@ const TruckNavLink: React.FC<TruckNavLinkProps> = ({ to, text, onClick }) => {
         viewBox="0 0 80 40"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <rect x="2" y="10" width="50" height="20" rx="2" className="truck-body" />
-        <rect x="52" y="16" width="12" height="12" rx="2" className="truck-cab" />
-        <polyline points="2,10 2,30 -6,26 -6,14 2,10" className="truck-door" />
-        <circle cx="16" cy="32" r="4" className="truck-wheel" />
-        <circle cx="44" cy="32" r="4" className="truck-wheel" />
+        <rect x="5" y="10" width="70" height="20" rx="4" className="truck-body" />
+        <circle cx="25" cy="32" r="4" className="truck-wheel" />
+        <circle cx="55" cy="32" r="4" className="truck-wheel" />
         <text
-          x="27"
+          x="40"
           y="20"
           textAnchor="middle"
           alignmentBaseline="middle"

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -8,7 +8,7 @@
 
 /* Truck navigation link styles */
 .truck-nav-link {
-  @apply inline-block transform transition-all duration-300 text-gray-100 font-heading;
+  @apply inline-block transform transition-all duration-300 text-white font-body;
 }
 .truck-nav-link:hover {
   @apply text-primary scale-110;
@@ -20,7 +20,7 @@
   @apply fill-current stroke-current;
 }
 .truck-text {
-  font-size: 0.875rem;
+  font-size: 1rem;
   font-weight: 700;
   text-anchor: middle;
   dominant-baseline: middle;


### PR DESCRIPTION
## Summary
- simplify TruckNavLink SVG so trailer text has more space
- bump font to 1rem and use body font for better readability

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684610170b2883209e88a07fec9edcdb