### PR TITLE
Improve navbar legibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.6",
+    "@fontsource/playfair-display": "^5.2.6",
+    "@fontsource/roboto": "^5.2.6",
     "@headlessui/react": "^1.7.8",
     "@heroicons/react": "^2.0.17",
     "@hookform/resolvers": "^5.1.0",
@@ -30,9 +33,7 @@
     "react-router-dom": "^6.11.1",
     "react-slick": "^0.29.0",
     "slick-carousel": "^1.8.1",
-    "zod": "^3.20.6",
-    "@fontsource/roboto": "^5.2.6",
-    "@fontsource/playfair-display": "^5.2.6"
+    "zod": "^3.20.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.16.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/inter':
+        specifier: ^5.2.6
+        version: 5.2.6
       '@fontsource/playfair-display':
         specifier: ^5.2.6
         version: 5.2.6
@@ -393,6 +396,9 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@fontsource/inter@5.2.6':
+    resolution: {integrity: sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==}
 
   '@fontsource/playfair-display@5.2.6':
     resolution: {integrity: sha512-hWfFm2j+Dlg+UwabNJu5vi45otmLSG64hUzNFJ8pIDBgqWBviEPpVaDIZWHm2RYyIxhg9YXTPsZWdpvsu7fkqQ==}
@@ -2653,6 +2659,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@fontsource/inter@5.2.6': {}
 
   '@fontsource/playfair-display@5.2.6': {}
 

--- a/src/layout/TruckNavLink.tsx
+++ b/src/layout/TruckNavLink.tsx
@@ -17,16 +17,16 @@ const TruckNavLink: React.FC<TruckNavLinkProps> = ({ to, text, onClick }) => {
       }
     >
       <svg
-        width="80"
+        width="112"
         height="40"
-        viewBox="0 0 80 40"
+        viewBox="0 0 112 40"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <rect x="5" y="10" width="70" height="20" rx="4" className="truck-body" />
-        <circle cx="25" cy="32" r="4" className="truck-wheel" />
-        <circle cx="55" cy="32" r="4" className="truck-wheel" />
+        <rect x="16" y="8" width="80" height="24" rx="4" className="truck-body" />
+        <circle cx="36" cy="32" r="4" className="truck-wheel" />
+        <circle cx="76" cy="32" r="4" className="truck-wheel" />
         <text
-          x="40"
+          x="56"
           y="20"
           textAnchor="middle"
           alignmentBaseline="middle"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import App from './App';
 import './styles/tailwind.css';
 import '@fontsource/roboto';
 import '@fontsource/playfair-display';
+import '@fontsource/inter';
 import 'aos/dist/aos.css';
 
 // Initialize React Query client

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -20,8 +20,11 @@
   @apply fill-current stroke-current;
 }
 .truck-text {
-  font-size: 1rem;
-  font-weight: 700;
+  font-family: 'Inter', sans-serif;
+  font-size: 1.125rem; /* ~18px */
+  font-weight: 500;
+  line-height: 1.2;
+  letter-spacing: 0.5px;
   text-anchor: middle;
   dominant-baseline: middle;
   font-style: normal;
@@ -29,6 +32,7 @@
 .truck-body,
 .truck-cab {
   stroke-width: 2;
+  stroke: currentColor;
   fill: none;
 }
 .truck-wheel {


### PR DESCRIPTION
## Summary
- install `@fontsource/inter`
- use Inter font for nav trailer text
- widen trailer SVG to add padding and adjust wheel/text position
- tweak truck text styles for clarity

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684611f8c938832081db66ebc1fd7185