### PR TITLE
Remove top padding from pages

### DIFF
--- a/src/pages/ServiceDetails.tsx
+++ b/src/pages/ServiceDetails.tsx
@@ -34,7 +34,7 @@ const ServiceDetails: React.FC = () => {
         <title>SPN Logistics | {service.title}</title>
         <meta name="description" content={`Details about ${service.title}.`} />
       </Helmet>
-      <div className="max-w-5xl mx-auto p-4 mt-20 space-y-4">
+      <div className="max-w-5xl mx-auto p-4 space-y-4">
         {service.image && (
           <img
             src={service.image}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -19,7 +19,7 @@ const AppRoutes: React.FC = () => {
       <Navbar />
       <ScrollToTopOnRouteChange />
       <ScrollTop />
-      <main className="pt-20">
+      <main>
         <Suspense
           fallback={
             <div className="min-h-screen flex items-center justify-center">


### PR DESCRIPTION
## Summary
- drop the extra top padding from `<main>`
- remove redundant margin-top on ServiceDetails page

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68462b0db1408320adcfeb420b42f29e