### PR TITLE
Adjust navbar background logic

### DIFF
--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -1,20 +1,31 @@
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import TruckNavLink from './TruckNavLink';
 import { Menu, X } from 'lucide-react';
 
 const Navbar: React.FC = () => {
+  const { pathname } = useLocation();
+  const isHome = pathname === '/';
+
   const [isOpen, setIsOpen] = useState(false);
-  const [scrolled, setScrolled] = useState(false);
+  const [scrolled, setScrolled] = useState(!isHome);
 
   useEffect(() => {
+    setScrolled(!isHome);
+  }, [isHome]);
+
+  useEffect(() => {
+    if (!isHome) return;
+
     const handleScroll = () => {
-      setScrolled(window.scrollY > 50);
+      const heroHeight = window.innerHeight;
+      setScrolled(window.scrollY > heroHeight);
     };
 
+    handleScroll();
     window.addEventListener('scroll', handleScroll);
     return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+  }, [isHome]);
 
   return (
     <header


### PR DESCRIPTION
## Summary
- use react-router to detect current page
- keep the navbar transparent only on the home page
- always show a solid navbar on other pages

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_684631be6e9c8320a4fb56ad74838f36