### PR TITLE
Fix content overlap with navbar

### DIFF
--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense } from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 import Navbar from '../layout/Navbar';
 import Footer from '../layout/Footer';
 import ScrollTop from '../layout/ScrollTop';
@@ -14,12 +14,15 @@ const Contact = lazy(() => import('../pages/Contact'));
 const NotFound = lazy(() => import('../pages/NotFound'));
 
 const AppRoutes: React.FC = () => {
+  const { pathname } = useLocation();
+  const isHome = pathname === '/';
+
   return (
     <>
       <Navbar />
       <ScrollToTopOnRouteChange />
       <ScrollTop />
-      <main>
+      <main className={isHome ? '' : 'pt-20'}>
         <Suspense
           fallback={
             <div className="min-h-screen flex items-center justify-center">


### PR DESCRIPTION
## Summary
- add `useLocation` hook to detect current path
- apply top padding to pages unless on the home page

## Testing
- `pnpm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6846ed6c74548320b4c8e719a9c5e746