### PR TITLE
Adjust icon color

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -116,28 +116,28 @@ const Home: React.FC = () => {
       <Section>
         <div className="grid grid-cols-2 md:grid-cols-4 gap-6 text-center">
           <div className="flex flex-col items-center gap-2">
-            <Truck className="text-primary" />
+            <Truck className="text-darkBg2" />
             <p className="text-3xl font-bold text-primary">
               <CountUp end={new Date().getFullYear() - 2020} duration={4} />+
             </p>
             <p>Experience Since 2020</p>
           </div>
           <div className="flex flex-col items-center gap-2">
-            <Route className="text-primary" />
+            <Route className="text-darkBg2" />
             <p className="text-3xl font-bold text-primary">
               <CountUp end={5000000} suffix="+" duration={4} />
             </p>
             <p>Miles Driven</p>
           </div>
           <div className="flex flex-col items-center gap-2">
-            <Package className="text-primary" />
+            <Package className="text-darkBg2" />
             <p className="text-3xl font-bold text-primary">
               <CountUp end={12000} suffix="+" duration={4} />
             </p>
             <p>Loads Delivered</p>
           </div>
           <div className="flex flex-col items-center gap-2">
-            <CheckCircle className="text-primary" />
+            <CheckCircle className="text-darkBg2" />
             <p className="text-3xl font-bold text-primary">
               <CountUp end={99} suffix="%" duration={4} />
             </p>
@@ -153,17 +153,17 @@ const Home: React.FC = () => {
             {
               title: 'LTL Shipping',
               slug: 'ltl',
-              icon: <Package className="w-10 h-10 text-primary" />,
+              icon: <Package className="w-10 h-10 text-darkBg2" />,
             },
             {
               title: 'FTL Shipping',
               slug: 'ftl',
-              icon: <Truck className="w-10 h-10 text-primary" />,
+              icon: <Truck className="w-10 h-10 text-darkBg2" />,
             },
             {
               title: 'Refrigerated Transport',
               slug: 'refrigerated',
-              icon: <Snowflake className="w-10 h-10 text-primary" />,
+              icon: <Snowflake className="w-10 h-10 text-darkBg2" />,
             },
           ].map((service) => (
             <Card

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -16,9 +16,9 @@ const Services: React.FC = () => {
   const [services, setServices] = useState<ServiceInfo[]>([]);
 
   const serviceIcons: Record<string, React.ReactNode> = {
-    ltl: <Package className="w-10 h-10 text-primary" />,
-    ftl: <Truck className="w-10 h-10 text-primary" />,
-    refrigerated: <Snowflake className="w-10 h-10 text-primary" />,
+    ltl: <Package className="w-10 h-10 text-darkBg2" />,
+    ftl: <Truck className="w-10 h-10 text-darkBg2" />,
+    refrigerated: <Snowflake className="w-10 h-10 text-darkBg2" />,
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- tone down the orange by setting icons to use the dark background color

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6852cf87db848320aa91bf19e3964836