### PR TITLE
Update service info and add animated background

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SPN Logistics</title>
   </head>
-  <body class="bg-white dark:bg-darkBg text-gray-800 dark:text-gray-100 font-body">
+  <body class="bg-white dark:bg-darkBg text-gray-800 dark:text-gray-100 font-body bg-animated">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -79,8 +79,8 @@ const About: React.FC = () => {
             },
             {
               src: SemiTruckImg,
-              title: "Semi Truck",
-              desc: "We operate all kinds of semi trucks to handle diverse hauling needs.",
+              title: "Flatbed",
+              desc: "Our versatile flatbeds safely move oversized or irregular freight with ease.",
             },
             {
               src: RefrigeratedImg,
@@ -110,7 +110,7 @@ const About: React.FC = () => {
       </Section>
 
       <Section title="Executive Team">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 justify-center place-items-center">
+        <div className="grid w-fit mx-auto grid-cols-1 md:grid-cols-3 gap-6 place-items-center">
           {[
             {
               name: "Parminder Singh",

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -43,3 +43,15 @@
   stroke-width: 2;
   fill: none;
 }
+
+@layer utilities {
+  @keyframes gradientBG {
+    0%, 100% { background-position: 0% 50%; }
+    50% { background-position: 100% 50%; }
+  }
+  .bg-animated {
+    background: linear-gradient(-45deg, #0d1321, #1d2a4d, #FF5722, #1E88E5);
+    background-size: 400% 400%;
+    animation: gradientBG 15s ease infinite;
+  }
+}


### PR DESCRIPTION
## Summary
- switch service label from **Semi Truck** to **Flatbed** on the About page
- ensure the executive team card stays centered
- add subtle animated gradient background via Tailwind utility

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68582c4bbb2c832086383a32e4a46b0c