### PR TITLE
Use video background across pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,16 @@
       as="video"
       type="video/mp4"
     />
+    <link
+      rel="preload"
+      href="/assets/Animation - 1750619673472.webm"
+      as="video"
+      type="video/webm"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>SPN Logistics</title>
   </head>
-  <body class="bg-white dark:bg-darkBg text-gray-800 dark:text-gray-100 font-body bg-animated">
+  <body class="bg-white dark:bg-darkBg text-gray-800 dark:text-gray-100 font-body">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/layout/BackgroundVideo.tsx
+++ b/src/layout/BackgroundVideo.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import bgVideo from '../assets/Animation - 1750619673472.webm';
+
+const BackgroundVideo: React.FC = () => (
+  <video
+    className="fixed inset-0 w-full h-full object-cover -z-10"
+    src={bgVideo}
+    autoPlay
+    loop
+    muted
+    playsInline
+  />
+);
+
+export default BackgroundVideo;

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import Button from '../ui/Button';
-import heroVideo from '../assets/mixkit-cargo-truck-driving-on-the-highway-28787-hd-ready.mp4';
 
 const NotFound: React.FC = () => {
   return (
@@ -12,14 +11,6 @@ const NotFound: React.FC = () => {
         <title>SPN Logistics | 404</title>
       </Helmet>
       <section className="relative h-screen flex items-center justify-center">
-        <video
-          className="absolute w-full h-full object-cover"
-          src={heroVideo}
-          autoPlay
-          loop
-          muted
-          playsInline
-        />
         <div className="absolute inset-0 bg-black/50" />
         <div className="relative z-10 text-center text-white px-4">
           <motion.h1

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -4,6 +4,7 @@ import Navbar from '../layout/Navbar';
 import Footer from '../layout/Footer';
 import ScrollTop from '../layout/ScrollTop';
 import ScrollToTopOnRouteChange from '../layout/ScrollToTopOnRouteChange';
+import BackgroundVideo from '../layout/BackgroundVideo';
 
 // Lazy-loaded pages
 const Home = lazy(() => import('../pages/Home'));
@@ -19,6 +20,7 @@ const AppRoutes: React.FC = () => {
 
   return (
     <>
+      {!isHome && <BackgroundVideo />}
       <Navbar />
       <ScrollToTopOnRouteChange />
       <ScrollTop />


### PR DESCRIPTION
## Summary
- remove global animated gradient background
- preload the new webm animation
- add `BackgroundVideo` component
- display video background on all pages except Home
- simplify 404 page layout

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68585aba61d8832086ae5d317a922672