### PR TITLE
Fix font import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@fontsource/inter": "^5.2.6",
     "@fontsource/poppins": "^5.2.6",
     "@fontsource/montserrat": "^5.2.6",
+    "@fontsource-variable/inter": "^5.2.6",
     "@headlessui/react": "^1.7.8",
     "@heroicons/react": "^2.0.17",
     "@hookform/resolvers": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/inter':
+        specifier: ^5.2.6
+        version: 5.2.6
       '@fontsource/inter':
         specifier: ^5.2.6
         version: 5.2.6
@@ -402,6 +405,9 @@ packages:
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@fontsource-variable/inter@5.2.6':
+    resolution: {integrity: sha512-jks/bficUPQ9nn7GvXvHtlQIPudW7Wx8CrlZoY8bhxgeobNxlQan8DclUJuYF2loYRrGpfrhCIZZspXYysiVGg==}
 
   '@fontsource/inter@5.2.6':
     resolution: {integrity: sha512-CZs9S1CrjD0jPwsNy9W6j0BhsmRSQrgwlTNkgQXTsAeDRM42LBRLo3eo9gCzfH4GvV7zpyf78Ozfl773826csw==}
@@ -2700,6 +2706,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@fontsource-variable/inter@5.2.6': {}
 
   '@fontsource/inter@5.2.6': {}
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import "@fontsource/inter/variable.css";
+@import "@fontsource-variable/inter/index.css";
 @import "@fontsource/poppins/600.css";
 @import "@fontsource/montserrat/700.css";
 


### PR DESCRIPTION
## Summary
- update dependencies to include `@fontsource-variable/inter`
- fix CSS import path for Inter variable font

## Testing
- `pnpm build`
- `pnpm test run`

------
https://chatgpt.com/codex/tasks/task_e_6858681baf10832096856958d1f195b6