### PR TITLE
Enhance services layouts and nav style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,7 @@ h1, h2, h3, h4, h5, h6 { @apply font-heading; }
   @apply inline-block transform transition-all duration-300 text-light font-body;
 }
 .truck-nav-link:hover {
-  @apply text-info scale-110;
+  @apply text-accent scale-110;
 }
 .truck-nav-link.active {
   @apply text-accent underline;

--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -58,7 +58,7 @@ const Navbar: React.FC = () => {
               <NavLink
                 to={to}
                 className={({ isActive }) =>
-                  `transition-colors hover:text-accent ${
+                  `transition-colors hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent rounded ${
                     isActive ? "text-accent underline" : ""
                   }`
                 }

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -44,6 +44,32 @@ const Services: React.FC = () => {
           ))}
         </div>
       </Section>
+      {services.map((service, index) => {
+        const layout = index % 3;
+        const layoutClass =
+          layout === 0
+            ? "md:flex-row"
+            : layout === 1
+            ? "md:flex-row-reverse"
+            : "";
+        return (
+          <Section key={service.slug}>
+            <div className={`flex flex-col items-center gap-6 md:gap-10 ${layoutClass}`}>
+              <img
+                src={service.image}
+                alt={service.title}
+                className="w-full md:w-1/2 h-64 object-cover rounded"
+              />
+              <div className="md:w-1/2 space-y-4 text-center md:text-left">
+                <h3 className="text-2xl font-bold text-primary font-heading">
+                  {service.title}
+                </h3>
+                <p>{service.description}</p>
+              </div>
+            </div>
+          </Section>
+        );
+      })}
     </>
   );
 };


### PR DESCRIPTION
## Summary
- alternate image/text layouts on Services page for visual interest
- swap TruckNavLink hover color to orange
- highlight active nav items with orange focus ring

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ae1fdef788320b76146e4ae767262