### PR TITLE
Improve hero overlay and lighten background

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -58,7 +58,7 @@ h1, h2, h3, h4, h5, h6 { @apply font-heading; }
     50% { background-position: 100% 50%; }
   }
   .animated-bg {
-    background: linear-gradient(130deg,#0d1117,#2088ff,#2a9d8f);
+    background: linear-gradient(130deg,#ffffff,#e0f2ff,#d0f5f0);
     background-size: 400% 400%;
     animation: gradientShift 18s ease infinite;
   }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -98,7 +98,7 @@ const Home: React.FC = () => {
           muted
           playsInline
         />
-        <div className="absolute inset-0 bg-primary/60 backdrop-blur" />
+        <div className="absolute inset-0 bg-black/60 backdrop-blur" />
         <div className="relative z-10 text-center text-white px-4">
           <motion.h1
             initial={{ opacity: 0, y: -20 }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,7 +20,7 @@ module.exports = {
         darkBg2: "#1E1E1E",
       },
       backgroundImage: {
-        "gradient-hero": "linear-gradient(to bottom right, #0d1321, #1d2a4d)",
+        "gradient-hero": "linear-gradient(to bottom right, #f3f9ff, #dceafe)",
       },
     },
   },


### PR DESCRIPTION
## Summary
- lighten the animated background gradient
- use a slightly darker overlay for the home hero video
- update footer gradient to a lighter theme

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae55c04fc83208b6d1bc4328313ee