### PR TITLE
Fix hero content under nav

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -120,7 +120,7 @@ const Home: React.FC = () => {
       </Helmet>
 
       {/* Enhanced Hero Section */}
-      <section className="relative h-screen flex items-center justify-center overflow-hidden">
+      <section className="relative h-screen flex items-center justify-center overflow-hidden -mt-20">
         {/* Video Background */}
         <div className="absolute inset-0 z-0">
           <video

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -22,7 +22,7 @@ const AppRoutes: React.FC = () => {
       <Navbar />
       <ScrollToTopOnRouteChange />
       <ScrollTop />
-      <main className={isHome ? '' : 'pt-20'}>
+      <main className="pt-20">
         <Suspense
           fallback={
             <div className="min-h-screen flex items-center justify-center">


### PR DESCRIPTION
## Summary
- prevent nav from overlapping hero by adding global top padding and offsetting the hero

## Testing
- `pnpm test` *(fails: `Tests failed. Watching for file changes...`)*

------
https://chatgpt.com/codex/tasks/task_e_6879bed071508320995dce08aa186a0b