### PR TITLE
Enhance service card clarity

### DIFF
--- a/src/layout/TruckNavLink.tsx
+++ b/src/layout/TruckNavLink.tsx
@@ -56,7 +56,7 @@ const TruckNavLink: React.FC<TruckNavLinkProps> = ({
       to={to}
       onClick={onClick}
       className={({ isActive }) => {
-        const baseClasses = `relative font-medium transition-all duration-300 overflow-hidden ${className}`;
+        const baseClasses = `relative font-medium transition-all duration-300 overflow-hidden focus:outline-none focus:ring-0 ${className}`;
         const activeClasses = isActive ? 'text-blue-600 dark:text-blue-400 font-semibold' : '';
         return `${baseClasses} ${activeClasses}`;
       }}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -153,7 +153,7 @@ const Services: React.FC = () => {
               <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent opacity-90 group-hover:opacity-95 transition-opacity duration-500" />
               
               {/* Content */}
-              <div className="relative h-full flex flex-col justify-end p-8">
+              <div className="relative h-full flex flex-col justify-end p-8 bg-black/50 backdrop-blur-sm rounded-b-3xl">
                 <motion.div
                   className="bg-white/20 backdrop-blur-sm rounded-2xl p-4 mb-6 w-fit"
                   whileHover={{ scale: 1.1 }}


### PR DESCRIPTION
## Summary
- enhance readability on service cards by adding a darker blurred backdrop
- remove the orange focus ring from navigation links

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d53f84508832092ebd090fd71c59a